### PR TITLE
typo: case of `@join__types` should be `@join__type`

### DIFF
--- a/photos.graphql
+++ b/photos.graphql
@@ -43,7 +43,7 @@ type User
 
 type Album
     @join__owner(graph: ALBUMS)
-    @join__types(graph: ALBUMS, key: "id") {
+    @join__type(graph: ALBUMS, key: "id") {
   id: ID!
   user: User
   photos: [Image!]


### PR DESCRIPTION
Looks like @join_types was a typo and instead intended to be @join_type